### PR TITLE
add CURLOPT_SSL_VERIFYPEER for ssl usage

### DIFF
--- a/lib/XmppPrebind.php
+++ b/lib/XmppPrebind.php
@@ -509,6 +509,7 @@ class XmppPrebind {
 	 */
 	protected function send($xml) {
 		$ch = curl_init($this->boshUri);
+		curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
 		curl_setopt($ch, CURLOPT_HEADER, 0);
 		curl_setopt($ch, CURLOPT_POST, 1);
 		curl_setopt($ch, CURLOPT_POSTFIELDS, $xml);


### PR DESCRIPTION
i added this line so cURL can connect via ssl
curl_setopt($ch, CURLOPT_SSL_VERIFYPEER, false);
It's working well
